### PR TITLE
Add experimental radio button utility

### DIFF
--- a/sample/src/main.ts
+++ b/sample/src/main.ts
@@ -73,7 +73,7 @@ function main(_param: g.GameMainParameterObject): void {
 								if (gui.radioButton("Axe🪓", valueObject, "radioButtonValue", "rb2")) {
 									console.log(`checkbox value ${valueObject.radioButtonValue}`);
 								}
-								if (gui.radioButton("Wand🪄", valueObject, "radioButtonValue", "rb3")) {
+								if (gui.rbu("rb3").radioButton("Wand🪄", valueObject, "radioButtonValue")) {
 									console.log(`checkbox value ${valueObject.radioButtonValue}`);
 								}
 							});

--- a/src/Gui.ts
+++ b/src/Gui.ts
@@ -10,6 +10,14 @@ import {
 import { WindowManager } from "./WindowManager";
 
 /**
+ * ラジオボタン生成役型。
+ *
+ * 実験的機能。将来変更されるかもしれない。
+ */
+interface RadioButtonCreator<U> {
+	radioButton<T extends ValueObject>(title: string, valueObject: T, key: ExtractPropertyNames<T, U>): boolean;
+}
+/**
  * ウィジェットのフォントサイズからウィジェットの高さを求める。
  *
  * @param font ウィジェットの用いるフォント。
@@ -805,6 +813,23 @@ export class Gui {
 	 */
 	radioButton<T extends ValueObject, U>(title: string, valueObject: T, key: ExtractPropertyNames<T, U>, buttonValue: U): boolean {
 		return this.add(radioButtonUi(title, valueObject, key, buttonValue));
+	}
+
+	/**
+	 * ラジオボタン型推定ユーティリティ。
+	 *
+	 * 実験的機能。将来変更されるかもしれない。
+	 *
+	 * @param value ラジオボタンが押下された時設定される値。
+	 * @returns
+	 */
+	rbu<U>(value: U): RadioButtonCreator<U> {
+		const _this = this;
+		return {
+			radioButton<T extends ValueObject>(title: string, valueObject: T, key: ExtractPropertyNames<T, U>): boolean {
+				return _this.radioButton(title, valueObject, key, value);
+			}
+		};
 	}
 
 	/**


### PR DESCRIPTION
実験的なラジオボタンの生成ユーティリティを追加します。ラジオボタンが値を書き込むプロパティの名前を推定することを助けることで、VSCodeなどでプログラムを編集するとき、適切なプロパティ名が入力候補として現れるようになります。